### PR TITLE
Direct self-hosters to kobo-install

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@ title: "KoBoToolbox | Data Collection Tools for Challenging Environments"
             </div>
         </div>
         <p class="centered">For more information on the differences between the two servers and to help determine which one is right for you, please read our <a href="http://support.kobotoolbox.org/getting-started/which-server-should-i-use">Which Server Should I Use?</a> support article.</p><br/>
-        <p class="centered">Advanced users can also install KoBoToolbox on their own server (or on a local machine) using Docker. See our <a href="https://github.com/kobotoolbox/kobo-docker">kobo-docker</a> repository on GitHub for details.</p>
+        <p class="centered">Advanced users can also install KoBoToolbox on their own server (or on a local machine) using Docker. See our <a href="https://github.com/kobotoolbox/kobo-install">kobo-install</a> repository on GitHub for details.</p>
     </div>
 </section>
 


### PR DESCRIPTION
(instead of kobo-docker)